### PR TITLE
Check if hat path exists

### DIFF
--- a/revpi-device-info
+++ b/revpi-device-info
@@ -8,6 +8,7 @@ import sys
 from sys import stderr
 
 from revpi_device_info import RevPiDeviceInfo, RevPiHatEEPROMAttributeException
+from revpi_device_info.device_info import RevPiHatEEPROMException
 
 
 def known_attributes():
@@ -79,7 +80,7 @@ if __name__ == "__main__":
 
     try:
         device_info = RevPiDeviceInfo(hat_path=args.hat_path)
-    except RevPiHatEEPROMAttributeException as e:
+    except (RevPiHatEEPROMAttributeException, RevPiHatEEPROMException) as e:
         print(
             f"An error occured while reading the HAT contents: {e}", file=stderr)
         sys.exit(1)

--- a/revpi_device_info/device_info.py
+++ b/revpi_device_info/device_info.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import json
+import os.path
 from datetime import date
 
+class RevPiHatEEPROMException(Exception):
+    pass
 
 class RevPiHatEEPROMAttributeException(Exception):
     pass
@@ -48,6 +51,10 @@ class RevPiDeviceInfo:
         Load values from RevPi HAT EEPROM
         :raises: RevPiHatEEPROMAttributeException: if the attribute cannot be read from HAT files
         """
+
+        if not os.path.exists(self._hat_path):
+            raise RevPiHatEEPROMException("HAT EEPROM path does not exists")
+
         self.uuid = self._hat_attribute("uuid")
         self.format_version = self._hat_attribute_int("custom_0")
 


### PR DESCRIPTION
... and raise exception if not. Also print error message in revpi-device-info.

As discussed in https://github.com/RevolutionPi/revpi-tools/pull/15 this PR shows a meaningful error message in case there is no HAT eeprom attached (or found)