### PR TITLE
Set upstream-branch value in gbp.conf to master

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,4 +1,5 @@
 [DEFAULT]
+upstream-branch = master
 upstream-tag = v%(version)s
 debian-branch = raspios/buster
 debian-tag = raspios/%(version)s


### PR DESCRIPTION
The default value is 'upstream' and tools like dch can not find the tag with the version number with the wrong upstream-branch value.