### PR TITLE
Set upstream-branch value in gbp.conf to master

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,4 +1,5 @@
 [DEFAULT]
+upstream-branch = master
 upstream-tag = v%(version)s
 debian-branch = raspios/bullseye
 debian-tag = raspios/%(version)s


### PR DESCRIPTION
The default value is 'upstream' and tools like dch can not find the tag with the version number with the wrong upstream-branch value.

Signed-off-by: Sven Sager <s.sager@kunbus.com>
(cherry picked from commit f1bc535366a587994a484285b16128060142a4f6)